### PR TITLE
feat(attachments): log warning if POST attachment returns 202

### DIFF
--- a/sw360/attachments.py
+++ b/sw360/attachments.py
@@ -12,8 +12,13 @@
 import json
 import os
 import requests
+import logging
 
 from .sw360error import SW360Error
+from http import HTTPStatus
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 
 class AttachmentsMixin:
@@ -206,6 +211,10 @@ class AttachmentsMixin:
             ),
         }
         response = requests.post(url, headers=self.api_headers, files=file_data)
+        if response.status_code == HTTPStatus.ACCEPTED:
+            logger.warning(
+                f"Attachment upload was accepted by {url} but might not be visible yet: {response.text}"
+            )
         if not response.ok:
             raise SW360Error(response, url)
 


### PR DESCRIPTION
Not sure if throwing an error is the right thing to do here but not informing the client, that the upload couldn't be performed is not a good choice. Since there is no logging configured in this module, I went for raising ;)

The API documentation released on SW360 servers is unfortunately not very verbose when it comes to POST responses for the `/attachments` endpoints, so I wrote a test based on experimental data.  

Closes #17 