### PR TITLE
feat: `update_project_releases` uses SW360 PATCH API call now

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,11 @@
 
 # SW360 Base Library for Python
 
+## UNRELEASED
+
+* use SW360 support for `update_project_releases(..., add=True)` instead of our own code.
+  This allows to pass a dict with release details (e.g. project mainline state or relation).
+
 ## V1.8.1
 
 * `delete_project` now works properly. Before it could have happened the you get a `JSONDecodeError`.

--- a/sw360/project.py
+++ b/sw360/project.py
@@ -367,21 +367,13 @@ class ProjectMixin(BaseMixin):
         if not project_id:
             raise SW360Error(message="No project id provided!")
 
-        if add:
-            old_releases = self.get_project_releases(project_id)
-            if (old_releases is not None and "_embedded" in old_releases
-                    and "sw360:releases" in old_releases["_embedded"]):
-                old_releases = old_releases["_embedded"]["sw360:releases"]
-                old_releases = [r["_links"]["self"]["href"] for r in old_releases]
-                old_releases = [r.split("/")[-1] for r in old_releases]
-                releases = old_releases + list(releases)
-
         url = self.url + "resource/api/projects/" + project_id + "/releases"
-        response = self.api_post(url, json=releases)
-        if response is not None:
-            if response.ok:
-                return True
-        return None
+        if add:
+            self.api_patch(url, json=releases)
+        else:
+            self.api_post(url, json=releases)
+
+        return True  # api_*() will raise an exception if something goes wrong
 
     def update_project_external_id(self, ext_id_name: str, ext_id_value: str,
                                    project_id: str, update_mode: str = "none") -> Any:

--- a/tests/test_sw360_projects.py
+++ b/tests/test_sw360_projects.py
@@ -1004,7 +1004,7 @@ class Sw360TestProjects(unittest.TestCase):
             json={},
         )
         responses.add(
-            responses.POST,
+            responses.PATCH,
             url=self.MYURL + "resource/api/projects/123/releases",
             status=202,
         )
@@ -1016,7 +1016,7 @@ class Sw360TestProjects(unittest.TestCase):
             json={'_embedded': {'sw360:projects': []}},
         )
         responses.add(
-            responses.POST,
+            responses.PATCH,
             url=self.MYURL + "resource/api/projects/124/releases",
             status=202,
         )
@@ -1036,9 +1036,9 @@ class Sw360TestProjects(unittest.TestCase):
         )
 
         responses.add(
-            responses.POST,
+            responses.PATCH,
             url=self.MYURL + "resource/api/projects/123/releases",
-            body="4",
+            body="",
             status=202,
         )
 
@@ -1059,9 +1059,9 @@ class Sw360TestProjects(unittest.TestCase):
         )
 
         responses.add(
-            responses.POST,
+            responses.PATCH,
             url=self.MYURL + "resource/api/projects/123/releases",
-            body="4",
+            body="",
             status=404,
         )
 


### PR DESCRIPTION
This removes our own patch handling for adding releases and also allows to pass a dict with release details now, e.g. to set relation or project mainline state for a linked release.