### PR TITLE
fix: comprehensive query param enconding

### DIFF
--- a/sw360/base.py
+++ b/sw360/base.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
 
+from urllib.parse import urlencode
+
 from .sw360error import SW360Error
 
 
@@ -217,16 +219,17 @@ class BaseMixin():
             update = False
 
         return (old_value, ext_id_data, update)
-
-    def _add_param(self, url: str, param: str) -> str:
+    
+    def _add_params(self, url: str, params: dict) -> str:
         """Add the given parameter to the given url"""
+        
+        query_string = urlencode(params)
+        
         if "?" in url:
-            url = url + "&"
+            return f"{url}&{query_string}"
         else:
-            url = url + "?"
-
-        return url + param
-
+            return f"{url}?{query_string}"
+            
     @classmethod
     def get_id_from_href(cls, href: str) -> str:
         """"Extracts the identifier from the href and returns it

--- a/sw360/components.py
+++ b/sw360/components.py
@@ -37,25 +37,25 @@ class ComponentsMixin(BaseMixin):
         :rtype: list of JSON component objects
         :raises SW360Error: if there is a negative HTTP response
         """
-
-        url = self.url + "resource/api/components"
+        
+        fullbase_url = self.url + "resource/api/components"
+        params = {}
 
         if all_details:
-            url = self._add_param(url, "allDetails=true")
+            params["allDetails"] = "true"
 
         if fields:
-            url = self._add_param(url, "fields=" + fields)
+            params["fields"] = fields
 
         if page > -1:
-            url = self._add_param(url, "page=" + str(page))
-            url = self._add_param(url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            url = self._add_param(url, "sort=" + sort)
+            params["sort"] = sort
 
-        resp = self.api_get(url)
+        full_url = self._add_params(fullbase_url, params)
+        resp = self.api_get(full_url)
         if not resp:
             return []
 
@@ -94,18 +94,18 @@ class ComponentsMixin(BaseMixin):
         :raises SW360Error: if there is a negative HTTP response
         """
 
-        url = self.url + "resource/api/components?type=" + component_type
+        fullbase_url = self.url + "resource/api/components"
+        params = {"type": component_type}
 
         if page > -1:
-            url = self._add_param(url, "page=" + str(page))
-            url = self._add_param(url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            url = self._add_param(url, "sort=" + sort)
+            params["sort"] = sort
 
-        resp = self.api_get(url)
+        full_url = self._add_params(fullbase_url, params)
+        resp = self.api_get(full_url)
 
         if resp and ("_embedded" in resp) and ("sw360:components" in resp["_embedded"]):
             return resp["_embedded"]["sw360:components"]
@@ -165,17 +165,18 @@ class ComponentsMixin(BaseMixin):
         :raises SW360Error: if there is a negative HTTP response
         """
 
-        url = self.url + "resource/api/components?name=" + component_name
+        fullbase_url = self.url + "resource/api/components?name=" + component_name
+        params = {"name": component_name}
+
         if page > -1:
-            url = self._add_param(url, "page=" + str(page))
-            url = self._add_param(url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            url = self._add_param(url, "sort=" + sort)
+            params["sort"] = sort
 
-        resp = self.api_get(url)
+        full_url = self._add_params(fullbase_url, params)
+        resp = self.api_get(full_url)
         return resp
 
     def get_components_by_external_id(self, ext_id_name: str, ext_id_value: str = "") -> List[Dict[str, Any]]:

--- a/sw360/moderationrequests.py
+++ b/sw360/moderationrequests.py
@@ -30,16 +30,17 @@ class ModerationRequestMixin(BaseMixin):
         :raises SW360Error: if there is a negative HTTP response
         """
 
-        full_url = self.url + "resource/api/moderationrequest"
+        fullbase_url = self.url + "resource/api/moderationrequest"
+        params = {}
+
         if page > -1:
-            full_url = self._add_param(full_url, "page=" + str(page))
-            full_url = self._add_param(full_url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            full_url = self._add_param(full_url, "sort=" + sort)
+            params["sort"] = sort
 
+        full_url = self._add_params(fullbase_url, params)
         resp = self.api_get(full_url)
         return resp
 
@@ -63,22 +64,23 @@ class ModerationRequestMixin(BaseMixin):
         :raises SW360Error: if there is a negative HTTP response
         """
 
-        full_url = self.url + "resource/api/moderationrequest/byState?state=" + state
+        fullbase_url = self.url + "resource/api/moderationrequest/byState"
+        params = {"state": state}
+        
         if all_details:
-            full_url = self._add_param(full_url, "allDetails=true")
+            params["allDetails"] = "true"
 
         if page > -1:
-            full_url = self._add_param(full_url, "page=" + str(page))
-            full_url = self._add_param(full_url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            full_url = self._add_param(full_url, "sort=" + sort)
+            params["sort"] = sort
 
+        full_url = self._add_params(fullbase_url, params)
         resp = self.api_get(full_url)
         return resp
-
+        
     def get_moderation_request(self, mr_id: str) -> Optional[Dict[str, Any]]:
         """Get information of about a moderation request
 

--- a/sw360/packages.py
+++ b/sw360/packages.py
@@ -65,26 +65,29 @@ class PackagesMixin(BaseMixin):
         :rtype: list of JSON package objects
         :raises SW360Error: if there is a negative HTTP response
         """
-        full_url = self.url + "resource/api/packages"
+        fullbase_url = self.url + "resource/api/packages"
+        params = {}
+        
         if all_details:
-            full_url = self._add_param(full_url, "allDetails=true")
+            params["allDetails"] = "true"
 
         if name:
-            full_url = self._add_param(full_url, "name=" + name)
-        if version:
-            full_url = self._add_param(full_url, "version=" + version)
-        if purl:
-            full_url = self._add_param(full_url, "purl=" + purl)
+            params["name"] = name
 
+        if version:
+            params["version"] = version
+
+        if purl:
+            params["purl"] = purl
+            
         if page > -1:
-            full_url = self._add_param(full_url, "page=" + str(page))
-            full_url = self._add_param(full_url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            full_url = self._add_param(full_url, "sort=" + sort)
+            params["sort"] = sort
 
+        full_url = self._add_params(fullbase_url, params)
         resp = self.api_get(full_url)
 
         if page == -1 and resp and ("_embedded" in resp) and ("sw360:packages" in resp["_embedded"]):
@@ -110,19 +113,17 @@ class PackagesMixin(BaseMixin):
         :rtype: list of JSON package objects
         :raises SW360Error: if there is a negative HTTP response
         """
-        full_url = self.url + "resource/api/packages"
-        full_url = self._add_param(full_url, "packageManager=" + str(manager))
+        fullbase_url = self.url + "resource/api/packages"
+        params = {"packageManager": manager}
 
         if page > -1:
-            full_url = self._add_param(full_url, "page=" + str(page))
-            full_url = self._add_param(full_url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            full_url = self._add_param(full_url, "sort=" + sort)
+            params["sort"] = sort
 
-        resp = self.api_get(full_url)
+        resp = self.api_get(fullbase_url)
 
         if page == -1 and resp and ("_embedded" in resp) and ("sw360:packages" in resp["_embedded"]):
             return resp["_embedded"]["sw360:packages"]

--- a/sw360/project.py
+++ b/sw360/project.py
@@ -83,19 +83,20 @@ class ProjectMixin(BaseMixin):
         :raises SW360Error: if there is a negative HTTP response
         """
 
-        full_url = self.url + "resource/api/projects"
+        fullbase_url = self.url + "resource/api/projects"
+        params = {}
+        
         if all_details:
-            full_url = self._add_param(full_url, "allDetails=true")
+            params["allDetails"] = "true"
 
         if page > -1:
-            full_url = self._add_param(full_url, "page=" + str(page))
-            full_url = self._add_param(full_url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            full_url = self._add_param(full_url, "sort=" + sort)
+            params["sort"] = sort
 
+        full_url = self._add_params(fullbase_url, params)
         resp = self.api_get(full_url)
         return resp
 

--- a/sw360/releases.py
+++ b/sw360/releases.py
@@ -85,24 +85,26 @@ class ReleasesMixin(BaseMixin):
         :rtype: list of JSON release objects
         :raises SW360Error: if there is a negative HTTP response
         """
-        full_url = self.url + "resource/api/releases"
+        fullbase_url = self.url + "resource/api/releases"
+        params = {}
+
         if all_details:
-            full_url = self._add_param(full_url, "allDetails=true")
+            params["allDetails"] = "true"
 
         if isNewClearingWithSourceAvailable:
-            full_url = self._add_param(full_url, "isNewClearingWithSourceAvailable=true")
+            params["isNewClearingWithSourceAvailable"] = "true"
 
         if fields:
-            full_url = self._add_param(full_url, "fields=" + fields)
+            params["fields"] = fields
 
         if page > -1:
-            full_url = self._add_param(full_url, "page=" + str(page))
-            full_url = self._add_param(full_url, "page_entries=" + str(page_size))
+            params["page"] = str(page)
+            params["page_entries"] = str(page_size)
 
         if sort:
-            # ensure HTML encoding
-            sort = sort.replace(",", "%2C")
-            full_url = self._add_param(full_url, "sort=" + sort)
+            params["sort"] = sort
+
+        full_url = self._add_params(fullbase_url, params)
 
         resp = self.api_get(full_url)
 


### PR DESCRIPTION
API calls have no comprehensive param encoding. 
For most params this is not really an issue but like "find component" can cause mismatches.

