### PR TITLE
fix: Relax input validation for `get_components_by_external_id()` and…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,10 @@
 
 # SW360 Base Library for Python
 
+## V1.11.1
+
+* Relax input validation for `get_components_by_external_id()` and `get_releases_by_external_id()`.
+
 ## V1.11.0
 
 * Update dependencies to fix CVE-2026-21441 in urllib3.

--- a/sw360/components.py
+++ b/sw360/components.py
@@ -204,9 +204,6 @@ class ComponentsMixin(BaseMixin):
         if not ext_id_name:
             raise SW360Error(message="No external id name provided!")
 
-        if not ext_id_value:
-            raise SW360Error(message="No external id value provided!")
-
         resp = self.api_get(
             self.url
             + "resource/api/components/searchByExternalIds?"

--- a/sw360/releases.py
+++ b/sw360/releases.py
@@ -139,9 +139,6 @@ class ReleasesMixin(BaseMixin):
         if not ext_id_name:
             raise SW360Error(message="No external id name provided!")
 
-        if not ext_id_value:
-            raise SW360Error(message="No external id value provided!")
-
         resp = self.api_get(
             self.url
             + "resource/api/releases/searchByExternalIds?"


### PR DESCRIPTION
… `get_releases_by_external_id()`