### PR TITLE
fix(health)!: migrate endpoint to api

### DIFF
--- a/sw360/sw360_api.py
+++ b/sw360/sw360_api.py
@@ -160,5 +160,5 @@ class SW360(
         :rtype: JSON health status object
         :raises SW360Error: if there is a negative HTTP response
         """
-        resp = self.api_get(self.url + "resource/health/")
+        resp = self.api_get(self.url + "resource/api/health/")
         return resp

--- a/tests/test_sw360_health.py
+++ b/tests/test_sw360_health.py
@@ -50,7 +50,7 @@ class Sw360TestHealth(unittest.TestCase):
 
         responses.add(
             method=responses.GET,
-            url=self.MYURL + "resource/health/",
+            url=self.MYURL + "resource/api/health/",
             body='{"status": "UP"}',
             status=200,
             content_type="application/json",


### PR DESCRIPTION
The backend has migrated the health endpoint to match with other endpoints under `/api`. So the URL is no longer `/resource/health` but `/resource/api/health`.

Marked it as a breaking change as this is a breaking change in backend starting version 19.1.0.

See: https://github.com/eclipse-sw360/sw360/commit/8020133890095b7fb32381d1ad8cd3c71ccafdd8